### PR TITLE
Fix panic in ExactMatch/Find

### DIFF
--- a/cedar_test.go
+++ b/cedar_test.go
@@ -14,7 +14,7 @@ var (
 		"a", "aa", "ab", "abc", "abcd", "abcdef",
 		"太阳系", "太阳系水星", "太阳系金星", "太阳系地球", "太阳系火星",
 		"太阳系木星", "太阳系土星", "太阳系天王星", "太阳系海王星",
-		"this", "this is", "this is a cedar.",
+		"this", "this is", "this is a cedar.", "CEMPAGA",
 	}
 )
 
@@ -62,6 +62,10 @@ func TestFind(t *testing.T) {
 	val, err = cd.Value(to)
 	tt.Nil(t, err)
 	tt.Equal(t, 3, val)
+
+	val, match := cd.ExactMatch([]byte("CEMPAGA"))
+	tt.Equal(t, 18, val)
+	tt.Equal(t, true, match)
 }
 
 func TestPrefixMatch(t *testing.T) {

--- a/fn.go
+++ b/fn.go
@@ -77,7 +77,7 @@ func (cd *Cedar) Jump(key []byte, from int) (to int, err error) {
 func (cd *Cedar) Find(key []byte, from int) (int, error) {
 	to, err := cd.Jump(key, from)
 	if cd.Reduced {
-		if cd.array[from].baseV >= 0 {
+		if cd.array[to].baseV >= 0 {
 			if err == nil && to != 0 {
 				return cd.array[to].baseV, nil
 			}


### PR DESCRIPTION
Attempt to fix:

- Issues: #1

Looking at reference code [lib.rs, L379](https://github.com/MnO2/cedarwood/blob/master/src/lib.rs#L379), variable `*from` is overwritten in the loop and should be replaced with variable `to` in [fn.go, L80](https://github.com/vcaesar/cedar/blob/main/fn.go#L80)
